### PR TITLE
Fix custom day labels not working

### DIFF
--- a/calendarorganizer.js
+++ b/calendarorganizer.js
@@ -31,11 +31,10 @@ function Calendar(id, size, labelSettings, colors, options) {
     if (options.months != undefined && options.months.length == 12) months = options.months;
 
     var label = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-    this.defaultLabels = label;
-
     if (options.days != undefined && options.days.length == 7) label = options.days;
 
     this.months = months;
+    this.defaultLabels = label;
 
     this.label = [];
     this.labels = [];


### PR DESCRIPTION
When trying to use the Calendar options for days, with different days from the default (days: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",  "Saturday" ]), the calendar wouldn't load the custom set day labels and would not load any day.
This was happening because the check of the custom labels was after the load.