### PR TITLE
Fixes February incorrect spelling in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ var calendar = new Calendar("calendarContainer", "small",
                             [ "#ffc107", "#ffa000", "#ffffff", "#ffecb3" ],
                             {
                                 days: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",  "Saturday" ],
-                                months: [ "January", "Feburary", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
+                                months: [ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
                                 indicator: false,
                                 placeholder: "<span>Custom Placeholder</span>"
                             });
@@ -107,7 +107,7 @@ var calendar = new Calendar("calendarContainer",         // HTML container ID,  
                               "#ffecb3" ],               // Text Dark Color                                                                        Required
                             { // Following is optional
                                 days: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",  "Saturday" ],
-                                months: [ "January", "Feburary", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
+                                months: [ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
                                 indicator: true,         // Day Event Indicator                                                                    Optional
                                 indicator_type: 1,       // Day Event Indicator Type (0 not to display num of events, 1 to display num of events)  Optional
                                 indicator_pos: "bottom", // Day Event Indicator Position (top, bottom)                                             Optional


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

The documentation had a typo which was causing February to be spelled as `Feburary` for anyone who tries to utilize the documentation to setup a working demo. 

## Supporting information

For more information check #28 

## Testing instructions

Make sure that February is spelled correctly in the README.